### PR TITLE
Use a 640x480 game canvas.

### DIFF
--- a/src/default-game-data.js
+++ b/src/default-game-data.js
@@ -8,8 +8,8 @@ define(function(require) {
     sprites: [],
     blocklyXml: '<xml xmlns="http://www.w3.org/1999/xhtml"></xml>',
     baseURL: 'assets/',
-    width: 288,
-    height: 216,
+    width: 640,
+    height: 480,
     backgroundColor: 0xf0f0f0
   };
 });

--- a/src/ui/css-sprite.jsx
+++ b/src/ui/css-sprite.jsx
@@ -36,11 +36,13 @@ define(function(require) {
         }
       }
 
+      var scale = this.props.scale || 1;
+
       return (
         <div style={{
-          width: frameWidth,
-          height: frameHeight,
-          backgroundSize: 'auto ' + frameHeight + 'px',
+          width: frameWidth * scale,
+          height: frameHeight * scale,
+          backgroundSize: 'auto ' + (frameHeight * scale) + 'px',
           backgroundImage: 'url(' + url + ')',
           backgroundPosition: -(frame * frameWidth) + 'px 0px'
         }}></div>

--- a/src/ui/modals/position-modal.jsx
+++ b/src/ui/modals/position-modal.jsx
@@ -13,6 +13,7 @@ define(function(require) {
                                             this.props.initialSprite);
       return {
         gameData: gameData,
+        scale: 0.5,
         sprite: this.props.initialSprite,
         movingSprite: this.props.initialSprite,
         isShown: false,
@@ -23,10 +24,11 @@ define(function(require) {
       var movable = this.refs.movable.getDOMNode();
       var hammer = this.hammer = new Hammer(movable);
       hammer.on('panmove', function(e) {
+        var iScale = 1 / this.state.scale;
         this.setState(React.addons.update(this.state, {
           movingSprite: {
-            x: {$set: this.state.sprite.x + e.deltaX},
-            y: {$set: this.state.sprite.y + e.deltaY}
+            x: {$set: this.state.sprite.x + e.deltaX * iScale},
+            y: {$set: this.state.sprite.y + e.deltaY * iScale}
           }
         }));
         // We could update the fields here, but this slows down
@@ -74,14 +76,16 @@ define(function(require) {
       var gameData = this.state.gameData;
       var sprite = this.state.sprite;
       var movingSprite = this.state.movingSprite;
+      var scale = this.state.scale;
 
       // An apparent bug on iOS 7 makes it so that transforms aren't
       // applied if the element isn't visible at the time that
       // the transform is set, so we'll wait until the modal is
       // fully shown before setting the transform.
       var movableTransform = this.state.isShown
-                             ? 'translate(' + movingSprite.x + 'px, ' +
-                                              movingSprite.y + 'px)'
+                             ? 'translate(' +
+                                (movingSprite.x * scale) + 'px, ' +
+                                (movingSprite.y * scale) + 'px) '
                              : '';
 
       var movableStyle = {
@@ -104,15 +108,13 @@ define(function(require) {
             <div style={{
               display: 'inline-block',
               position: 'relative',
-              width: gameData.width,
-              marginLeft: -20,
-              marginRight: -20
+              width: gameData.width * scale
             }}>
               <div style={{opacity: 0.5, pointerEvents: 'none'}}>
-                <Stage ref="stage" width={gameData.width} height={gameData.height} phaserState={this.state.phaserState}/>
+                <Stage ref="stage" scale={scale} width={gameData.width} height={gameData.height} phaserState={this.state.phaserState}/>
               </div>
               <div ref="movable" style={movableStyle}>
-                <CssSprite gameData={gameData} sprite={sprite}/>
+                <CssSprite scale={scale} gameData={gameData} sprite={sprite}/>
               </div>
             </div>
             <p>Just drag the object around.</p>

--- a/src/ui/modals/position-modal.jsx
+++ b/src/ui/modals/position-modal.jsx
@@ -6,14 +6,17 @@ define(function(require) {
   var Modal = require('jsx!./modal');
   var Stage = require('jsx!../stage');
   var CssSprite = require('jsx!../css-sprite');
+  var ScaleSizerMixin = require('../scale-sizer-mixin');
 
   var PositionModal = React.createClass({
+    mixins: [ScaleSizerMixin],
     getInitialState: function() {
       var gameData = GameData.withoutSprite(this.props.initialGameData,
                                             this.props.initialSprite);
       return {
         gameData: gameData,
         scale: 0.4,
+        scaleIdealWidth: gameData.width,
         sprite: this.props.initialSprite,
         movingSprite: this.props.initialSprite,
         isShown: false,
@@ -40,6 +43,7 @@ define(function(require) {
       }.bind(this));
     },
     handleShown: function() {
+      this.handleScaleResize();
       this.setState({
         isShown: true,
         // Firefox doesn't like it if we initialize Phaser while its
@@ -104,7 +108,7 @@ define(function(require) {
 
       return (
         <Modal title={"Set position for " + sprite.name} onCancel={this.props.onCancel} onSave={this.handleSave} onFinished={this.props.onFinished} onShown={this.handleShown}>
-          <div style={{textAlign: 'center'}}>
+          <div ref="scaleContainer" style={{textAlign: 'center'}}>
             <div style={{
               display: 'inline-block',
               position: 'relative',

--- a/src/ui/modals/position-modal.jsx
+++ b/src/ui/modals/position-modal.jsx
@@ -13,7 +13,7 @@ define(function(require) {
                                             this.props.initialSprite);
       return {
         gameData: gameData,
-        scale: 0.5,
+        scale: 0.4,
         sprite: this.props.initialSprite,
         movingSprite: this.props.initialSprite,
         isShown: false,

--- a/src/ui/modals/position-modal.jsx
+++ b/src/ui/modals/position-modal.jsx
@@ -30,8 +30,8 @@ define(function(require) {
         var iScale = 1 / this.state.scale;
         this.setState(React.addons.update(this.state, {
           movingSprite: {
-            x: {$set: this.state.sprite.x + e.deltaX * iScale},
-            y: {$set: this.state.sprite.y + e.deltaY * iScale}
+            x: {$set: Math.floor(this.state.sprite.x + e.deltaX * iScale)},
+            y: {$set: Math.floor(this.state.sprite.y + e.deltaY * iScale)}
           }
         }));
         // We could update the fields here, but this slows down

--- a/src/ui/modals/rect-modal.jsx
+++ b/src/ui/modals/rect-modal.jsx
@@ -9,7 +9,7 @@ define(function(require) {
     getInitialState: function() {
       return {
         phaserState: null,
-        scale: 0.5,
+        scale: 0.4,
         rect: this.props.initialRect,
         rectAnchor: null
       };

--- a/src/ui/modals/rect-modal.jsx
+++ b/src/ui/modals/rect-modal.jsx
@@ -35,10 +35,12 @@ define(function(require) {
         var iScale = 1 / this.state.scale;
         this.setState({
           rect: {
-            left: (e.deltaX < 0 ? anchor.x + e.deltaX : anchor.x) * iScale,
-            top: (e.deltaY < 0 ? anchor.y + e.deltaY : anchor.y) * iScale,
-            width: Math.abs(e.deltaX) * iScale,
-            height: Math.abs(e.deltaY) * iScale
+            left: Math.floor((e.deltaX < 0 ? anchor.x + e.deltaX
+                                           : anchor.x) * iScale),
+            top: Math.floor((e.deltaY < 0 ? anchor.y + e.deltaY
+                                          : anchor.y) * iScale),
+            width: Math.floor(Math.abs(e.deltaX) * iScale),
+            height: Math.floor(Math.abs(e.deltaY) * iScale)
           }
         });
       }.bind(this));

--- a/src/ui/modals/rect-modal.jsx
+++ b/src/ui/modals/rect-modal.jsx
@@ -9,6 +9,7 @@ define(function(require) {
     getInitialState: function() {
       return {
         phaserState: null,
+        scale: 0.5,
         rect: this.props.initialRect,
         rectAnchor: null
       };
@@ -28,12 +29,13 @@ define(function(require) {
       }.bind(this));
       hammer.on('panmove', function(e) {
         var anchor = this.state.rectAnchor;
+        var iScale = 1 / this.state.scale;
         this.setState({
           rect: {
-            left: e.deltaX < 0 ? anchor.x + e.deltaX : anchor.x,
-            top: e.deltaY < 0 ? anchor.y + e.deltaY : anchor.y,
-            width: Math.abs(e.deltaX),
-            height: Math.abs(e.deltaY)
+            left: (e.deltaX < 0 ? anchor.x + e.deltaX : anchor.x) * iScale,
+            top: (e.deltaY < 0 ? anchor.y + e.deltaY : anchor.y) * iScale,
+            width: Math.abs(e.deltaX) * iScale,
+            height: Math.abs(e.deltaY) * iScale
           }
         });
       }.bind(this));
@@ -78,6 +80,7 @@ define(function(require) {
     render: function() {
       var gameData = this.props.gameData;
       var rect = this.state.rect;
+      var scale = this.state.scale;
 
       return (
         <Modal title={this.props.title || "Draw a rectangle"} onCancel={this.props.onCancel} onSave={this.handleSave} onFinished={this.props.onFinished} onShown={this.handleShown}>
@@ -85,26 +88,24 @@ define(function(require) {
             <div style={{
               display: 'inline-block',
               position: 'relative',
-              width: gameData.width,
-              marginLeft: -20,
-              marginRight: -20
+              width: gameData.width * scale
             }}>
               <div style={{opacity: 0.5, pointerEvents: 'none'}}>
-                <Stage ref="stage" width={gameData.width} height={gameData.height} phaserState={this.state.phaserState}/>
+                <Stage ref="stage" scale={scale} width={gameData.width} height={gameData.height} phaserState={this.state.phaserState}/>
               </div>
               <div ref="surface" style={{
                 position: 'absolute',
                 top: 0,
                 left: 0,
-                width: gameData.width,
-                height: gameData.height,
+                width: gameData.width * scale,
+                height: gameData.height * scale,
               }}>
                 <div ref="rect" style={{
                   position: 'absolute',
-                  top: rect.top,
-                  left: rect.left,
-                  width: rect.width,
-                  height: rect.height,
+                  top: rect.top * scale,
+                  left: rect.left * scale,
+                  width: rect.width * scale,
+                  height: rect.height * scale,
                   border: '1px solid red',
                   pointerEvents: 'none'
                 }}></div>

--- a/src/ui/modals/rect-modal.jsx
+++ b/src/ui/modals/rect-modal.jsx
@@ -4,12 +4,15 @@ define(function(require) {
   var PhaserState = require('../../phaser-state');
   var Modal = require('jsx!./modal');
   var Stage = require('jsx!../stage');
+  var ScaleSizerMixin = require('../scale-sizer-mixin');
 
   var RectModal = React.createClass({
+    mixins: [ScaleSizerMixin],
     getInitialState: function() {
       return {
         phaserState: null,
         scale: 0.4,
+        scaleIdealWidth: this.props.gameData.width,
         rect: this.props.initialRect,
         rectAnchor: null
       };
@@ -49,6 +52,7 @@ define(function(require) {
       this.hammer = null;
     },
     handleShown: function() {
+      this.handleScaleResize();
       this.setState({
         // Firefox doesn't like it if we initialize Phaser while its
         // window isn't visible, so we'll wait until it's shown.
@@ -84,7 +88,7 @@ define(function(require) {
 
       return (
         <Modal title={this.props.title || "Draw a rectangle"} onCancel={this.props.onCancel} onSave={this.handleSave} onFinished={this.props.onFinished} onShown={this.handleShown}>
-          <div style={{textAlign: 'center'}}>
+          <div ref="scaleContainer" style={{textAlign: 'center'}}>
             <div style={{
               display: 'inline-block',
               position: 'relative',

--- a/src/ui/player.jsx
+++ b/src/ui/player.jsx
@@ -6,7 +6,7 @@ define(function(require) {
     getInitialState: function() {
       return {
         isPaused: true,
-        scale: 0.5,
+        scale: 0.4,
         phaserState: this.makePhaserState()
       };
     },

--- a/src/ui/player.jsx
+++ b/src/ui/player.jsx
@@ -1,12 +1,15 @@
 define(function(require) {
   var React = require('react');
   var Stage = require('jsx!./stage');
+  var ScaleSizerMixin = require('./scale-sizer-mixin');
 
   var Player = React.createClass({
+    mixins: [ScaleSizerMixin],
     getInitialState: function() {
       return {
         isPaused: true,
         scale: 0.4,
+        scaleIdealWidth: this.props.gameData.width,
         phaserState: this.makePhaserState()
       };
     },

--- a/src/ui/player.jsx
+++ b/src/ui/player.jsx
@@ -6,6 +6,7 @@ define(function(require) {
     getInitialState: function() {
       return {
         isPaused: true,
+        scale: 0.5,
         phaserState: this.makePhaserState()
       };
     },
@@ -43,14 +44,16 @@ define(function(require) {
       this.resetGame(this.props);
     },
     render: function() {
+      var scale = this.state.scale;
+
       return (
         <div style={{textAlign: 'center'}}>
           <div style={{
             display: 'inline-block',
-            width: this.props.gameData.width
+            width: this.props.gameData.width * scale
           }}>
             <div style={{pointerEvents: this.state.isPaused ? 'none' : 'auto'}}>
-              <Stage width={this.props.gameData.width} height={this.props.gameData.height} phaserState={this.state.phaserState}/>
+              <Stage scale={scale} width={this.props.gameData.width} height={this.props.gameData.height} phaserState={this.state.phaserState}/>
             </div>
             <div className="btn-group btn-group-justified">
               <div className="btn-group">

--- a/src/ui/scale-sizer-mixin.js
+++ b/src/ui/scale-sizer-mixin.js
@@ -1,0 +1,24 @@
+define(function() {
+  return {
+    handleScaleResize: function() {
+      var scaleContainer = this.refs.scaleContainer || this;
+      var rect = scaleContainer.getDOMNode().getBoundingClientRect();
+      var idealWidth = this.state.scaleIdealWidth;
+      var newScale;
+      if (rect.width >= idealWidth) {
+        newScale = 1;
+      } else {
+        newScale = rect.width / idealWidth;
+      }
+      if (this.state.scale != newScale)
+        this.setState({scale: newScale});
+    },
+    componentDidMount: function() {
+      window.addEventListener('resize', this.handleScaleResize);
+      this.handleScaleResize();
+    },
+    componentWillUnmount: function() {
+      window.removeEventListener('resize', this.handleScaleResize);
+    }
+  };
+});

--- a/src/ui/stage.jsx
+++ b/src/ui/stage.jsx
@@ -1,6 +1,8 @@
 define(function(require) {
   var React = require('react');
 
+  var TRANSFORM_ORIGIN = '0 0';
+
   var Stage = React.createClass({
     propTypes: {
       width: React.PropTypes.number,
@@ -12,6 +14,13 @@ define(function(require) {
     },
     setPhaserState: function(newState) {
       var hardReset = !newState || (this.iframe && !this.game);
+
+      // An apparent bug on iOS 7 makes it so that transforms aren't
+      // applied if the element isn't visible at the time that
+      // the transform is set. This helps us get around that bug.
+      var transform = this.refs.transform.getDOMNode();
+      transform.style.webkitTransform = this.getTransform();
+      transform.style.webkitTransformOrigin = TRANSFORM_ORIGIN;
 
       if (this.game && this.game.canvas && newState) {
         this.refs.placeholder.getDOMNode().getContext('2d').drawImage(
@@ -81,21 +90,24 @@ define(function(require) {
     componentWillUnmount: function() {
       this.setPhaserState(null);
     },
+    getTransform: function() {
+      return 'scale(' + (this.props.scale) + ')';
+    },
     render: function() {
-      var scale = this.props.scale || 1;
-      var transform = 'scale(' + scale + ')';
+      var scale = this.props.scale;
+      var transform = this.getTransform();
       var transformStyle = {
         transform: transform,
         webkitTransform: transform,
         mozTransform: transform,
-        transformOrigin: '0 0',
-        webkitTransformOrigin: '0 0',
-        mozTransformOrigin: '0 0',
+        transformOrigin: TRANSFORM_ORIGIN,
+        webkitTransformOrigin: TRANSFORM_ORIGIN,
+        mozTransformOrigin: TRANSFORM_ORIGIN,
       };
 
       return (
         <div style={{height: this.props.height * scale, overflow: 'hidden'}}>
-        <div style={transformStyle}>
+        <div ref="transform" style={transformStyle}>
         <div style={{
           position: 'relative',
           width: this.props.width + 'px',

--- a/src/ui/stage.jsx
+++ b/src/ui/stage.jsx
@@ -82,7 +82,10 @@ define(function(require) {
       this.setPhaserState(null);
     },
     render: function() {
+      var scale = this.props.scale || 1;
       return (
+        <div style={{height: this.props.height * scale, overflow: 'hidden'}}>
+        <div style={{transform: 'scale(' + scale + ')', transformOrigin: '0 0'}}>
         <div style={{
           position: 'relative',
           width: this.props.width + 'px',
@@ -99,6 +102,8 @@ define(function(require) {
             display: this.state.loading ? 'block' : 'none'
           }}
         /><div ref="phaser"/></div>
+        </div>
+        </div>
       );    
     }
   });

--- a/src/ui/stage.jsx
+++ b/src/ui/stage.jsx
@@ -83,9 +83,19 @@ define(function(require) {
     },
     render: function() {
       var scale = this.props.scale || 1;
+      var transform = 'scale(' + scale + ')';
+      var transformStyle = {
+        transform: transform,
+        webkitTransform: transform,
+        mozTransform: transform,
+        transformOrigin: '0 0',
+        webkitTransformOrigin: '0 0',
+        mozTransformOrigin: '0 0',
+      };
+
       return (
         <div style={{height: this.props.height * scale, overflow: 'hidden'}}>
-        <div style={{transform: 'scale(' + scale + ')', transformOrigin: '0 0'}}>
+        <div style={transformStyle}>
         <div style={{
           position: 'relative',
           width: this.props.width + 'px',

--- a/templates/export-template.html
+++ b/templates/export-template.html
@@ -3,27 +3,17 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <style>
-html, body {
+html, body, #phaser-holder {
   width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
-}
-
-body {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  display: -webkit-flex;
-  -webkit-justify-content: center;
-  -webkit-align-items: center;
+  overflow: hidden;
 }
 </style>
 <title>My Minigame</title>
-<div>
-  <div id="phaser-holder"></div><% if (encourageRemix) { %>
-  <p><small><a href="javascript:remixGame()">Remix this minigame</a></small></p><% } %>
+<div id="phaser-holder"></div><% if (encourageRemix) { %>
+<span style="position: absolute; bottom: 8px; left: 8px"><small><a href="javascript:remixGame()">Remix this minigame</a></small></span><% } %>
 </div>
 <script src="//cdnjs.cloudflare.com/ajax/libs/phaser/<%= phaserVersion %>/phaser.min.js"></script>
 <script src="//toolness.github.io/fancy-friday/contrib/tinygame.js"></script>
@@ -37,6 +27,13 @@ var game = new Phaser.Game(
   'phaser-holder',
   state
 );
+
+state.on('preload', function() {
+  game.scale.scaleMode = Phaser.ScaleManager.SHOW_ALL;
+  game.scale.setMinMax(0, 0, <%= gameData.width %>, <%= gameData.height %>);
+  game.scale.pageAlignVertically = true;
+  game.scale.pageAlignHorizontally = true;
+});
 
 // Safari caches cross-origin resources in a ridiculous way.
 // We'll work around this annoyance by monkeypatching 

--- a/templates/phaser-state-template.js
+++ b/templates/phaser-state-template.js
@@ -24,6 +24,7 @@ var state = SimpleEventEmitter({
       throw new Error("Expected Phaser <%= expectedPhaserVersion %> but got " +
                       this.Phaser.VERSION);
     preload(this.game);
+    this.trigger('preload');
   },
   create: function() {
     createSprites(this);


### PR DESCRIPTION
Chloe's sprites are really made for a bigger screen, and playing a 320x240 game on a tablet or desktop feels totally lame. So let's try increasing the canvas size to 640x480, but downscale to 320x240 on mobile phones.

To do:
- [x] Exported games don't yet use Phaser's ScaleManager, so they always show at 640x480, even on mobile. Change this so they look like http://jsbin.com/tetaye/1/.
- [x] The in-editor scaling should be more dynamic/responsive, not hard-coded to 0.5 like it currently is.
