### PR TITLE
Add collapsible JS panel to Blockly editor

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -200,7 +200,8 @@ div.btn-group-justified > div.btn-group:last-child {
 }
 #blockly-holder .blockly-js-panel {
   display: none;
-  overflow: auto;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
   padding: 10px;
 }
 #blockly-holder .blockly-fill-page:not(.blockly-js-expanded) > .blockly-js-toggle .caret {

--- a/css/base.css
+++ b/css/base.css
@@ -182,6 +182,41 @@ div.btn-group-justified > div.btn-group:last-child {
   color: black;
   background-color: #ffff66;
 }
+#blockly-holder .blockly-js-toggle {
+  font-family: 'Open Sans Extrabold';
+  font-weight: normal;
+  text-transform: uppercase;
+  position: absolute;
+  bottom: 0px;
+  left: 0px;
+  z-index: 1;
+  cursor: pointer;
+  background: #2f7fb8;
+  color: white;
+  padding: 10px;
+}
+#blockly-holder .blockly-panel {
+  height: 100%;
+}
+#blockly-holder .blockly-js-panel {
+  display: none;
+  overflow: auto;
+  padding: 10px;
+}
+#blockly-holder .blockly-fill-page:not(.blockly-js-expanded) > .blockly-js-toggle .caret {
+  border-top: 0;
+  border-bottom: 4px solid;
+}
+#blockly-holder .blockly-fill-page.blockly-js-expanded > .blockly-panel {
+  height: 75%;
+}
+#blockly-holder .blockly-fill-page.blockly-js-expanded > .blockly-js-panel {
+  display: block;
+  height: 25%;
+}
+#blockly-holder .blockly-fill-page.blockly-js-expanded > .blockly-js-toggle {
+  bottom: 25%;
+}
 @media (max-width: 480px) {
   .hidden-teensy {
     display: none;

--- a/css/base.less
+++ b/css/base.less
@@ -230,6 +230,49 @@ div.btn-group-justified > div.btn-group:last-child {
     color: black;
     background-color: @lightyellow;
   }
+
+  .blockly-js-toggle {
+    .ultra-bold;
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    z-index: 1;
+    cursor: pointer;
+    background: @darkblue;
+    color: white;
+    padding: 10px;
+  }
+
+  .blockly-panel {
+    height: 100%;
+  }
+
+  .blockly-js-panel {
+    display: none;
+    overflow: auto;
+    padding: 10px;
+  }
+
+  .blockly-fill-page:not(.blockly-js-expanded) >
+  .blockly-js-toggle .caret {
+    border-top: 0;
+    border-bottom: 4px solid;
+  }
+
+  .blockly-fill-page.blockly-js-expanded {
+    > .blockly-panel {
+      height: 75%;
+    }
+
+    > .blockly-js-panel {
+      display: block;
+      height: 25%;
+    }
+
+    > .blockly-js-toggle {
+      bottom: 25%;
+    }
+  }
 }
 
 @media (max-width: 480px) {

--- a/css/base.less
+++ b/css/base.less
@@ -249,7 +249,8 @@ div.btn-group-justified > div.btn-group:last-child {
 
   .blockly-js-panel {
     display: none;
-    overflow: auto;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     padding: 10px;
   }
 

--- a/src/phaser-blocks.js
+++ b/src/phaser-blocks.js
@@ -107,12 +107,17 @@ define(function(require) {
     },
     generateJs: function(newGameData) {
       Blockly.Phaser.setGameData(newGameData);
-      soundsUsed = [];
+      var currentSoundsUsed = soundsUsed = [];
 
       var xml = Blockly.Xml.workspaceToDom(Blockly.mainWorkspace);
       xml = Blockly.Xml.domToText(xml);
 
-      var blocklyLines = Blockly.JavaScript.workspaceToCode().split('\n');
+      try {
+        var blocklyLines = Blockly.JavaScript.workspaceToCode().split('\n');
+      } finally {
+        soundsUsed = null;
+      }
+
       var lines = [
         'function start(state) {',
         '  var game = state.game;',
@@ -129,7 +134,7 @@ define(function(require) {
 
       return {
         start: lines.join('\n'),
-        soundsUsed: soundsUsed
+        soundsUsed: currentSoundsUsed
       };
     }
   };
@@ -277,7 +282,8 @@ define(function(require) {
   };
 
   Blockly.JavaScript['phaser_play_sound'] = function(block) {
-    soundsUsed.push(block.getFieldValue('SOUND'));
+    if (soundsUsed)
+      soundsUsed.push(block.getFieldValue('SOUND'));
     return 'sounds.' + block.getFieldValue('SOUND') + '.play();\n';
   };
 

--- a/src/ui/blockly-component.jsx
+++ b/src/ui/blockly-component.jsx
@@ -3,16 +3,58 @@ define(function(require) {
   var Blockly = require('blockly');
 
   var BlocklyComponent = React.createClass({
+    getInitialState: function() {
+      return {
+        showJsPanel: false,
+        js: ''
+      };
+    },
     componentDidMount: function() {
       Blockly.inject(this.refs.blockly.getDOMNode(), {
         path: 'vendor/blockly/',
         toolbox: this.props.toolbox
       });
+      Blockly.addChangeListener(this.handleBlocklyChange);
+    },
+    componentWillUnmount: function() {
+      Blockly.removeChangeListener(this.handleBlocklyChange);
+      // TODO: Un-inject Blockly?
+    },
+    componentDidUpdate: function(prevProps, prevState) {
+      if (this.state.showJsPanel != prevState.showJsPanel) {
+        Blockly.fireUiEvent(window, 'resize');
+        if (this.state.showJsPanel)
+          this.handleBlocklyChange();
+      }
+    },
+    handleBlocklyChange: function() {
+      if (!this.state.showJsPanel) return;
+      var js = Blockly.JavaScript.workspaceToCode();
+      this.setState({
+        js: js
+      });
+    },
+    handleToggleJsPanel: function() {
+      this.setState({
+        showJsPanel: !this.state.showJsPanel
+      });
     },
     render: function() {
       return (
-        <div className="blockly-fill-page">
-          <div className="blockly-fill-page" ref="blockly"></div>
+        <div className={React.addons.classSet({
+          "blockly-fill-page": true,
+          "blockly-js-expanded": this.state.showJsPanel
+        })}>
+          <div className="blockly-panel" ref="blockly"></div>
+          <div className="blockly-js-panel">
+            <p>Below is the <a href="http://phaser.io/" target="_blank">Phaser</a>-based JavaScript translation for your Blockly code.</p>
+            <pre>{this.state.js}</pre>
+            <p>
+              <small><strong>Note: </strong>
+              This isn't all the code for your minigame. To see the full code, export your minigame to HTML via the <span className="glyphicon glyphicon-flash"></span> <strong>MOAR</strong> button in the main editor.
+              </small></p>
+          </div>
+          <div className="blockly-js-toggle" onClick={this.handleToggleJsPanel}>JS <span className="caret"></span></div>
           <div className="close-box" onClick={this.props.onClose}>&times;</div>
         </div>
       );


### PR DESCRIPTION
This allows users to easily see the JS translation of their Blockly code via a collapsible panel at the bottom of the Blockly editor:

![2015-02-01_9-23-26](https://cloud.githubusercontent.com/assets/124687/5992351/1459b256-a9f4-11e4-9a32-9cb490acb2fe.jpg)
