### PR TITLE
Introduce schema migrations for game data

### DIFF
--- a/blockly-toolbox.xml
+++ b/blockly-toolbox.xml
@@ -22,7 +22,6 @@
         <block type="phaser_set_animation"></block>
         <block type="phaser_set_sprite_numeric_prop"></block>
         <block type="phaser_get_sprite_numeric_prop"></block>
-        <block type="phaser_sprites_overlap"></block>
         <block type="phaser_sprites_overlap_with_tolerance"></block>
         <block type="phaser_win"></block>
         <block type="phaser_lose"></block>

--- a/require-config.js
+++ b/require-config.js
@@ -21,6 +21,11 @@ var require = {
   jsx: {
     fileExtension: '.jsx'
   },
+  packages: [
+    {
+      name: "src/migrations"
+    }
+  ],
   shim: {
     "prism": {
       exports: "Prism"

--- a/src/default-game-data.js
+++ b/src/default-game-data.js
@@ -5,6 +5,7 @@ define(function(require) {
   var EMPTY_BLOCKLY_XML = '<xml xmlns="http://www.w3.org/1999/xhtml"></xml>';
 
   return {
+    version: 1,
     sounds: assets.sounds,
     spritesheets: assets.spritesheets,
     animations: assets.animations,

--- a/src/export.js
+++ b/src/export.js
@@ -6,12 +6,20 @@ define(function(require) {
   var React = require('react');
   var GameData = require('./game-data');
   var PhaserState = require('./phaser-state');
+  var migrations = require('./migrations');
 
   var DEFAULT_NETWORK_TIMEOUT = 10000;
 
   var Export = {
     _templateString: require('text!codegen-templates/export-template.html'),
+    _migrateWrapper: function(cb) {
+      return function(err, gameData) {
+        if (err) return cb(err);
+        return cb(null, migrations.migrate(gameData));
+      };
+    },
     fromJson: function(baseURL, gameData, cb) {
+      cb = Export._migrateWrapper(cb);
       if (typeof(gameData) == 'string')
         // Looks like gameData is a URL pointing to a JSON blob.
         return Export.fromUrl(resolveURL(gameData, baseURL), cb);

--- a/src/migrations/0001-overlap-with-tolerance.js
+++ b/src/migrations/0001-overlap-with-tolerance.js
@@ -1,0 +1,22 @@
+define(function(require) {
+  var Blockly = require('blockly');
+  var $ = require('jquery');
+
+  function migrate(xml) {
+    xml = xml.split('\n').map(function(line) {
+      return line.trim();
+    }).join('');
+    var dom = Blockly.Xml.textToDom(xml);
+    $('block[type=phaser_sprites_overlap]', dom).each(function() {
+      $(this).attr('type', 'phaser_sprites_overlap_with_tolerance');
+      var field = document.createElement('field');
+      $(field).attr('name', 'TOLERANCE').text('0');
+      $(this).append(field);
+    });
+    return Blockly.Xml.domToPrettyText(dom);
+  }
+
+  return function migrateOverlapBlock(gameData) {
+    gameData.blocklyXml = migrate(gameData.blocklyXml);
+  };
+});

--- a/src/migrations/0001-overlap-with-tolerance.js
+++ b/src/migrations/0001-overlap-with-tolerance.js
@@ -3,9 +3,6 @@ define(function(require) {
   var $ = require('jquery');
 
   function migrate(xml) {
-    xml = xml.split('\n').map(function(line) {
-      return line.trim();
-    }).join('');
     var dom = Blockly.Xml.textToDom(xml);
     $('block[type=phaser_sprites_overlap]', dom).each(function() {
       $(this).attr('type', 'phaser_sprites_overlap_with_tolerance');
@@ -13,7 +10,7 @@ define(function(require) {
       $(field).attr('name', 'TOLERANCE').text('0');
       $(this).append(field);
     });
-    return Blockly.Xml.domToPrettyText(dom);
+    return Blockly.Xml.domToText(dom);
   }
 
   return function migrateOverlapBlock(gameData) {

--- a/src/migrations/main.js
+++ b/src/migrations/main.js
@@ -1,0 +1,28 @@
+define(function(require) {
+  var _ = require('underscore');
+
+  var migrations = [
+    require('./0001-overlap-with-tolerance')
+  ];
+
+  function migrate(gameData, options) {
+    options = _.defaults(options || {}, {
+      maxVersion: Infinity
+    });
+
+    if (typeof(gameData.version) == 'undefined')
+      gameData.version = 0;
+
+    while (gameData.version < options.maxVersion &&
+           gameData.version < migrations.length) {
+      migrations[gameData.version](gameData);
+      gameData.version++;
+    }
+
+    return gameData;
+  }
+
+  return {
+    migrate: migrate
+  };
+});

--- a/src/migrations/main.js
+++ b/src/migrations/main.js
@@ -6,6 +6,12 @@ define(function(require) {
     require('./0001-overlap-with-tolerance')
   ];
 
+  function unprettifyXml(xml) {
+    return xml.split('\n').map(function(line) {
+      return line.trim();
+    }).join('');
+  }
+
   function prettifyXml(xml) {
     return Blockly.Xml.domToPrettyText(Blockly.Xml.textToDom(xml));
   }
@@ -19,10 +25,8 @@ define(function(require) {
     if (typeof(gameData.version) == 'undefined')
       gameData.version = 0;
 
-    gameData.blocklyXml = gameData.blocklyXml
-      .split('\n').map(function(line) {
-        return line.trim();
-      }).join('');
+    if (options.prettifyXml)
+      gameData.blocklyXml = unprettifyXml(gameData.blocklyXml);
 
     while (gameData.version < options.maxVersion &&
            gameData.version < migrations.length) {
@@ -30,9 +34,8 @@ define(function(require) {
       gameData.version++;
     }
 
-    if (options.prettifyXml) {
+    if (options.prettifyXml)
       gameData.blocklyXml = prettifyXml(gameData.blocklyXml);
-    }
 
     return gameData;
   }

--- a/src/migrations/main.js
+++ b/src/migrations/main.js
@@ -1,22 +1,37 @@
 define(function(require) {
   var _ = require('underscore');
+  var Blockly = require('blockly');
 
   var migrations = [
     require('./0001-overlap-with-tolerance')
   ];
 
+  function prettifyXml(xml) {
+    return Blockly.Xml.domToPrettyText(Blockly.Xml.textToDom(xml));
+  }
+
   function migrate(gameData, options) {
     options = _.defaults(options || {}, {
-      maxVersion: Infinity
+      maxVersion: Infinity,
+      prettifyXml: false
     });
 
     if (typeof(gameData.version) == 'undefined')
       gameData.version = 0;
 
+    gameData.blocklyXml = gameData.blocklyXml
+      .split('\n').map(function(line) {
+        return line.trim();
+      }).join('');
+
     while (gameData.version < options.maxVersion &&
            gameData.version < migrations.length) {
       migrations[gameData.version](gameData);
       gameData.version++;
+    }
+
+    if (options.prettifyXml) {
+      gameData.blocklyXml = prettifyXml(gameData.blocklyXml);
     }
 
     return gameData;

--- a/src/phaser-blocks.js
+++ b/src/phaser-blocks.js
@@ -355,28 +355,6 @@ define(function(require) {
             Blockly.JavaScript.ORDER_ATOMIC];
   };
 
-  Blockly.Blocks['phaser_sprites_overlap'] = {
-    init: function() {
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldDropdown(spriteList), 'SPRITE1');
-      this.appendDummyInput().appendField('overlaps')
-        .appendField(new Blockly.FieldDropdown(spriteList), 'SPRITE2');
-      this.setOutput(true, 'Boolean');
-      this.setInputsInline(true);
-    }
-  };
-
-  Blockly.JavaScript['phaser_sprites_overlap'] = function(block) {
-    var sprite1 = spriteName(block, 'SPRITE1');
-    var sprite2 = spriteName(block, 'SPRITE2');
-    if (!sprite1 || !sprite2)
-      return ['false', Blockly.JavaScript.ORDER_ATOMIC];
-
-    return ['Phaser.Rectangle.intersects(' +
-            sprite1 + '.getBounds(), ' + sprite2 + '.getBounds())',
-            Blockly.JavaScript.ORDER_ATOMIC];
-  };
-
   Blockly.Blocks['phaser_sprites_overlap_with_tolerance'] = {
     init: function() {
       this.appendDummyInput()

--- a/test/all-tests.js
+++ b/test/all-tests.js
@@ -3,5 +3,6 @@ defineTests.combine([
   "test/test-examples",
   "test/test-export",
   "test/test-game-data",
+  "test/test-migrations",
   "test/test-css-sprite"
 ]);

--- a/test/test-migrations.js
+++ b/test/test-migrations.js
@@ -13,7 +13,10 @@ defineTests([
         '  </block>',
         '</xml>'
       ].join('\n')
-    }, {maxVersion: 1}), {
+    }, {
+      maxVersion: 1,
+      prettifyXml: true
+    }), {
       version: 1,
       blocklyXml: [
         '<xml xmlns="http://www.w3.org/1999/xhtml">',

--- a/test/test-migrations.js
+++ b/test/test-migrations.js
@@ -1,0 +1,40 @@
+defineTests([
+  "src/phaser-blocks",
+  "jquery"
+], function(Blockly, $) {
+  module("migrations");
+
+  function migrate(xml) {
+    xml = xml.split('\n').map(function(line) {
+      return line.trim();
+    }).join('');
+    var dom = Blockly.Xml.textToDom(xml);
+    $('block[type=phaser_sprites_overlap]', dom).each(function() {
+      $(this).attr('type', 'phaser_sprites_overlap_with_tolerance');
+      var field = document.createElement('field');
+      $(field).attr('name', 'TOLERANCE').text('0');
+      $(this).append(field);
+    });
+    return Blockly.Xml.domToPrettyText(dom);
+  }
+
+  test("upgrading phaser_sprites_overlap works", function() {
+    var xml = [
+      '<xml xmlns="http://www.w3.org/1999/xhtml">',
+      '  <block type="phaser_sprites_overlap" id="456">',
+      '    <field name="SPRITE1">a</field>',
+      '    <field name="SPRITE2">b</field>',
+      '  </block>',
+      '</xml>'
+    ].join('\n');
+    equal(migrate(xml), [
+      '<xml xmlns="http://www.w3.org/1999/xhtml">',
+      '  <block type="phaser_sprites_overlap_with_tolerance" id="456">',
+      '    <field name="SPRITE1">a</field>',
+      '    <field name="SPRITE2">b</field>',
+      '    <field name="TOLERANCE">0</field>',
+      '  </block>',
+      '</xml>'
+    ].join('\n'));
+  });
+});

--- a/test/test-migrations.js
+++ b/test/test-migrations.js
@@ -1,40 +1,29 @@
 defineTests([
-  "src/phaser-blocks",
-  "jquery"
-], function(Blockly, $) {
+  "src/migrations",
+], function(migrations) {
   module("migrations");
 
-  function migrate(xml) {
-    xml = xml.split('\n').map(function(line) {
-      return line.trim();
-    }).join('');
-    var dom = Blockly.Xml.textToDom(xml);
-    $('block[type=phaser_sprites_overlap]', dom).each(function() {
-      $(this).attr('type', 'phaser_sprites_overlap_with_tolerance');
-      var field = document.createElement('field');
-      $(field).attr('name', 'TOLERANCE').text('0');
-      $(this).append(field);
+  test("0001-overlap-with-tolerance", function() {
+    deepEqual(migrations.migrate({
+      blocklyXml: [
+        '<xml xmlns="http://www.w3.org/1999/xhtml">',
+        '  <block type="phaser_sprites_overlap" id="456">',
+        '    <field name="SPRITE1">a</field>',
+        '    <field name="SPRITE2">b</field>',
+        '  </block>',
+        '</xml>'
+      ].join('\n')
+    }, {maxVersion: 1}), {
+      version: 1,
+      blocklyXml: [
+        '<xml xmlns="http://www.w3.org/1999/xhtml">',
+        '  <block type="phaser_sprites_overlap_with_tolerance" id="456">',
+        '    <field name="SPRITE1">a</field>',
+        '    <field name="SPRITE2">b</field>',
+        '    <field name="TOLERANCE">0</field>',
+        '  </block>',
+        '</xml>'
+      ].join('\n')
     });
-    return Blockly.Xml.domToPrettyText(dom);
-  }
-
-  test("upgrading phaser_sprites_overlap works", function() {
-    var xml = [
-      '<xml xmlns="http://www.w3.org/1999/xhtml">',
-      '  <block type="phaser_sprites_overlap" id="456">',
-      '    <field name="SPRITE1">a</field>',
-      '    <field name="SPRITE2">b</field>',
-      '  </block>',
-      '</xml>'
-    ].join('\n');
-    equal(migrate(xml), [
-      '<xml xmlns="http://www.w3.org/1999/xhtml">',
-      '  <block type="phaser_sprites_overlap_with_tolerance" id="456">',
-      '    <field name="SPRITE1">a</field>',
-      '    <field name="SPRITE2">b</field>',
-      '    <field name="TOLERANCE">0</field>',
-      '  </block>',
-      '</xml>'
-    ].join('\n'));
   });
 });


### PR DESCRIPTION
As MMM evolves, we'll want to handle remixing old versions of the game data schema when we can. This applies most immediately to our example games, where we'd like to automate the process of upgrading to new versions of the schema.

This PR introduces a basic migration system with one initial migration, which migrates games from the version 0 schema, where `phaser_sprites_overlap` is a block, to the version 1 schema, where we have replaced that block with `phaser_sprites_overlap_with_tolerance` (which was introduced as a fix for #48).
